### PR TITLE
Accept-Encoding gzip and deflate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Make sure you have `$GOPATH/bin` added to your `$PATH` environment variable.
 * Basic Authentication
 * Serve over HTTPS (default)
 * Handle (log) POST requests for quick debugging
+* gzip and deflate (zlib) compression via the Accept-Encoding header
 
 ## Usage
 


### PR DESCRIPTION
Hey Shiv, I use this pretty regularly to serve files off my system, and today I needed the ability to test out some content served to the client as `Content-Encoding: gzip` when negotiated with `Accept-Encoding: gzip`. This should take care of it.

Used this as reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding

Would have added lzw, bzip2, and br, but [their implementations](https://golang.org/pkg/compress/) aren't simple `io.WriteCloser`s, so I skipped them.